### PR TITLE
Add capability to inform callers about the progress of StringGenerator.render_list

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,22 @@ n x 10 where n is the requested length of the list. Therefore, taking
 the above example, the generator will attempt to generate the unique
 list of 0's and 1's 100 x 10 = 1000 times before giving up.
 
+
+Progress
+--------
+
+When using the `progress_callback` parameter of the `render_list()` method,
+it's possible to inform others about the progress of string generation.
+This is especially useful when generating a large number of strings.
+
+The callback function obtains two int parameters: `(current, total)`,
+which define the current progress and the total amount of requested
+strings.
+
+By using that, callers of `render_list()` are able to implement a progress indicator
+suitable for informing end users about the progress of string generation.
+
+
 Unicode
 -------
 
@@ -427,6 +443,15 @@ This package is designed with the following goals in mind:
   developers to quickly pick up the template syntax.
 
 * Support non-ASCII languages (unicode).
+
+
+Testing
+-------
+For running the unit tests, you might want to try:
+
+    pip install pytest
+    pytest strgen/test.py --verbose
+
 
 License
 -------

--- a/strgen/__init__.py
+++ b/strgen/__init__.py
@@ -463,7 +463,7 @@ class StringGenerator(object):
         self.seq.dump()
         return self.render()
 
-    def render_list(self, cnt, unique=False):
+    def render_list(self, cnt, unique=False, progress_callback=None):
         '''Return a list of generated strings.
 
         Args:
@@ -495,4 +495,9 @@ class StringGenerator(object):
                 rendered_list.append(s)
                 i += 1
             total_attempts += 1
+
+            # Optionally trigger the progress indicator to inform others about our progress
+            if progress_callback and callable(progress_callback):
+                progress_callback(i, cnt)
+
         return rendered_list

--- a/strgen/test.py
+++ b/strgen/test.py
@@ -60,6 +60,25 @@ class TestStringGenerator(unittest.TestCase):
             print("Pattern [{0}] list length == {1}".format(t, len(result)))
             self.assertTrue(isinstance(result, list) and len(result) == list_length)
 
+    def test_list_progress(self):
+        """Check if the progress indicator actually works"""
+
+        list_length = 10
+
+        progress_states = []
+        def progress_callback(current, total):
+            progress_state = u'{current}/{total}'.format(**locals())
+            progress_states.append(progress_state)
+
+        StringGenerator(u"[a-z\d\d\d\d]{8}").render_list(list_length, progress_callback=progress_callback)
+
+        # Length of list of progress states should match length of requested strings
+        self.assertTrue(len(progress_states) == list_length)
+
+        # Check the first and the last item for the sake of completeness
+        self.assertEqual(progress_states[0], u'1/10')
+        self.assertEqual(progress_states[-1], u'10/10')
+
     def test_syntax_exception(self):
         '''Make sure syntax errors in template are caught.'''
         test_list = [


### PR DESCRIPTION
Dear Paul,

first things first: Thanks a bunch for conceiving and maintaining this cool library.

We are generating large amounts of unique strings using `StringGenerator.render_list` (>10,000), so we needed the capability to inform users about its progress as it might take some time to complete.

We did this by adding a simple callback-based notification thing to `StringGenerator.render_list` to keep the footprint as low as possible. This can be used to propagate the current index as well as the total amount of strings to anyone interested.

With kind regards,
Andreas.