### PR TITLE
Fix a syntax error caused by a missed %

### DIFF
--- a/strgen/__init__.py
+++ b/strgen/__init__.py
@@ -331,7 +331,7 @@ class StringGenerator(object):
             t = tmp
         if (ord(t) - ord(f)) > 10000:  # protect against large sets ?
             raise Exception(
-                "character range too large: %s - %s: %s"(f, t, ord(t) - ord(f))
+                "character range too large: %s - %s: %s" % (f, t, ord(t) - ord(f))
             )
         for c in range(ord(f), ord(t) + 1):
             chars += chr(c)


### PR DESCRIPTION
Without the `%`, Python thinks you're making a function call. We're seeing it as a syntax warning when starting our app:

```
/usr/local/lib/python3.8/site-packages/strgen/__init__.py:297: SyntaxWarning: 'str' object is not callable; perhaps you missed a comma?
  raise Exception(u"character range too large: %s - %s: %s"(f, t, ord(t) - ord(f)))
```